### PR TITLE
Draw different tensor field icons (circle/square) if radial or grid

### DIFF
--- a/src/ts/impl/basis_field.ts
+++ b/src/ts/impl/basis_field.ts
@@ -1,11 +1,17 @@
 import Tensor from './tensor';
 import Vector from '../vector';
 
+export const enum FIELD_TYPE {
+    Radial,
+    Grid,
+};
+
 /**
  * Grid or Radial field to be combined with others to create the tensor field
  */
 export abstract class BasisField {
     abstract readonly FOLDER_NAME: string;
+    abstract readonly FIELD_TYPE: number;
     protected static folderNameIndex: number = 0;
     protected parentFolder: dat.GUI;
     protected folder: dat.GUI;
@@ -91,6 +97,7 @@ export abstract class BasisField {
 
 export class Grid extends BasisField {
     readonly FOLDER_NAME = `Grid ${Grid.folderNameIndex++}`;
+    readonly FIELD_TYPE = FIELD_TYPE.Grid;
 
     constructor(centre: Vector, size: number, decay: number, private _theta: number) {
         super(centre, size, decay);
@@ -118,6 +125,8 @@ export class Grid extends BasisField {
 
 export class Radial extends BasisField {
     readonly FOLDER_NAME = `Radial ${Radial.folderNameIndex++}`;
+    readonly FIELD_TYPE = FIELD_TYPE.Radial;
+
     constructor(centre: Vector, size: number, decay: number) {
         super(centre, size, decay);
     }

--- a/src/ts/impl/tensor_field.ts
+++ b/src/ts/impl/tensor_field.ts
@@ -78,6 +78,10 @@ export default class TensorField {
         return this.basisFields.map(field => field.centre);
     }
 
+    getBasisFields(): BasisField[] {
+        return this.basisFields;
+    }
+
     samplePoint(point: Vector): Tensor {
         if (!this.onLand(point)) {
             // Degenerate point

--- a/src/ts/ui/canvas_wrapper.ts
+++ b/src/ts/ui/canvas_wrapper.ts
@@ -183,6 +183,13 @@ export class DefaultCanvasWrapper extends CanvasWrapper {
         }
     }
 
+    drawCircle(centre: Vector, radius: number): void {
+        const TAU = 2 * Math.PI;
+        this.ctx.beginPath();
+        this.ctx.arc(centre.x, centre.y, radius, 0, TAU);
+        this.ctx.fill();
+    }
+
     drawSquare(centre: Vector, radius: number): void {
         this.drawRectangle(centre.x - radius, centre.y - radius, 2 * radius, 2 * radius);
     }

--- a/src/ts/ui/tensor_field_gui.ts
+++ b/src/ts/ui/tensor_field_gui.ts
@@ -4,7 +4,7 @@ import DomainController from './domain_controller';
 import DragController from './drag_controller';
 import TensorField from '../impl/tensor_field';
 import {NoiseParams} from '../impl/tensor_field';
-import {BasisField} from '../impl/basis_field';
+import {BasisField, FIELD_TYPE} from '../impl/basis_field';
 import Util from '../util';
 import Vector from '../vector';
 
@@ -125,8 +125,10 @@ export default class TensorFieldGUI extends TensorField {
         // Draw centre points of fields
         if (this.drawCentre) {
             canvas.setFillStyle('red');
-            this.getCentrePoints().forEach(v =>
-                canvas.drawSquare(this.domainController.worldToScreen(v), 7));
+            this.getBasisFields().forEach(field => 
+                field.FIELD_TYPE === FIELD_TYPE.Grid ?
+                canvas.drawSquare(this.domainController.worldToScreen(field.centre), 7) :
+                canvas.drawCircle(this.domainController.worldToScreen(field.centre), 7))
         }
     }
 


### PR DESCRIPTION
Someone on the itch.io page mentioned implementing a way to better determine, through the icon, on the tensor field view, whether a field was a grid or a radial. With this, grids are the default squares and radials are circles.